### PR TITLE
fix deprecation warnings

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -11,7 +11,7 @@ use std::env;
 use std::error::Error;
 use std::path::PathBuf;
 
-fn main() -> Result<(), Box<Error>> {
+fn main() -> Result<(), Box<dyn Error>> {
     // parse in our options from the command line args
     let options = Options::from(&mut env::args_os());
 

--- a/src/options.rs
+++ b/src/options.rs
@@ -7,7 +7,7 @@ use crate::cleaner::*;
 
 /// Options struct to store configuration state.
 pub struct Options {
-    pub(crate) cleaners: Vec<Box<Cleaner>>,
+    pub(crate) cleaners: Vec<Box<dyn Cleaner>>,
     pub(crate) locations: Vec<PathBuf>,
 }
 


### PR DESCRIPTION
The following warnings are fixed:

    warning: trait objects without an explicit `dyn` are deprecated
      --> src/options.rs:10:34
       |
    10 |     pub(crate) cleaners: Vec<Box<Cleaner>>,
       |                                  ^^^^^^^ help: use `dyn`: `dyn Cleaner`
       |
       = note: `#[warn(bare_trait_objects)]` on by default

and

    warning: trait objects without an explicit `dyn` are deprecated
      --> src/main.rs:14:29
       |
    14 | fn main() -> Result<(), Box<Error>> {
       |                             ^^^^^ help: use `dyn`: `dyn Error

Those warnings were also emitted in the previous run of GitHub Actions workflow: https://github.com/whitfin/detox/actions/runs/518890544