### PR TITLE
make clippy happy

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,7 @@ use crate::options::Options;
 
 use std::env;
 use std::error::Error;
-use std::path::PathBuf;
+use std::path::Path;
 
 fn main() -> Result<(), Box<dyn Error>> {
     // parse in our options from the command line args
@@ -47,7 +47,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                     .expect("dir should be a str");
 
                 // clean the directory
-                cleaner.clean(&dir)?;
+                cleaner.clean(dir)?;
             }
         }
 
@@ -69,7 +69,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 }
 
 /// Determines the size of a directory on the filesystem.
-fn get_size(path: &PathBuf) -> u64 {
+fn get_size(path: &Path) -> u64 {
     WalkDir::new(path)
         .into_iter()
         .filter_map(Result::ok)


### PR DESCRIPTION
Fixes two `clippy` warnings:

    Warning:   --> src/main.rs:50:31
       |
    50 |                 cleaner.clean(&dir)?;
       |                               ^^^^ help: change this to: `dir`
       |
       = note: `#[warn(clippy::needless_borrow)]` on by default
       = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow

and

    warning: writing `&PathBuf` instead of `&Path` involves a new object where a slice will do
    Warning:   --> src/main.rs:72:19
       |
    72 | fn get_size(path: &PathBuf) -> u64 {
       |                   ^^^^^^^^ help: change this to: `&Path`
       |
       = note: `#[warn(clippy::ptr_arg)]` on by default
       = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#ptr_arg

These warnings occurred e.g. there: https://github.com/whitfin/detox/actions/runs/1019103081